### PR TITLE
docs: Add security policy outlining responsible disclosure and reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# 🔐 Security Policy for ChimeMate
+
+ChimeMate is committed to the security and privacy of its users and contributors. This policy explains how we handle security vulnerabilities and outlines the process for reporting them.
+
+## 🛠 Supported Versions
+
+ChimeMate is actively maintained. We encourage all users to upgrade to the latest version to benefit from security fixes and improvements.
+
+## ⚠️ 📢 Reporting a Vulnerability
+
+If you discover a security vulnerability in ChimeMate, please follow these guidelines for responsible disclosure:
+
+1. **Contact Us Privately:**  
+   Please send an email detailing the vulnerability to:  
+   **security@chen-abudi.com**  
+   (Replace with your designated security contact email.)
+
+2. **Include Detailed Information:**  
+   Your report should include:
+
+   - A clear description of the vulnerability.
+   - Steps to reproduce the issue.
+   - The potential impact of the vulnerability.
+   - Any suggested mitigations or fixes.
+   - Relevant environment details (e.g., version of ChimeMate, OS, etc.).
+
+3. **Wait for a Response:**  
+   Please allow us a reasonable time (typically up to 90 days) to address the issue before any public disclosure. We commit to acknowledging your report within 72 hours and working diligently to resolve the vulnerability.
+
+## 🔄 Responsible Disclosure Process
+
+- **Acknowledgment:** We will acknowledge the receipt of your report within 72 hours.
+- **Investigation:** We will investigate the issue and work on a fix as quickly as possible.
+- **Communication:** We will keep you updated on our progress.
+- **Public Disclosure:** Once the vulnerability has been resolved (or after the agreed-upon disclosure period), we may issue a public advisory that summarizes the issue without revealing sensitive details.
+
+## 💰 Bug Bounty
+
+At this time, ChimeMate does not have a formal bug bounty program. However, we greatly appreciate your efforts to help us improve our security. In some cases, we may consider rewards on a case-by-case basis for responsible disclosures.
+
+## 🎯 Security Best Practices
+
+- **Keep Dependencies Updated:** Regularly update your version of ChimeMate and its dependencies.
+- **Secure Your Environment:** Use secure configurations and follow best practices in your development environment.
+- **Follow Secure Coding Practices:** Refer to our [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on writing secure code.
+
+## 📬 Contact Information
+
+For any security-related queries or to report vulnerabilities, please contact us via email at **security@chen-abudi.com**. If you cannot reach us by email, please contact a project maintainer directly through GitHub.
+
+## Disclaimer
+
+ChimeMate is provided on an “as-is” basis. While we strive to keep the project secure, we are not liable for any issues that arise from its use. Your cooperation and responsible reporting are essential to improving the overall security of the project.
+
+---
+
+Thank you for helping keep ChimeMate secure! 🔐💻


### PR DESCRIPTION
- Added a comprehensive `SECURITY.md` file to define the **security** policy for ChimeMate.
- Outlined the process for **reporting** vulnerabilities and the responsible disclosure process.
- Provided **initial contact** details and **best practices** for maintaining **ChimeMate**'s security policy.