### PR TITLE
feat(commit-tracking): Implement commit logging and GitHub API fetch

### DIFF
--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { CommitLogEntry } from "../types/commitLog";
+import { logCommit } from "../utils/commitLogger";
+
+/**
+ * Fetches the latest commit from GitHub and logs it.
+ * @param repo - Repository name
+ * @param branch - Branch name
+ * @param token - OAuth token
+ */
+export const fetchLatestCommit = async (
+  repo: string,
+  branch: string,
+  token: string
+): Promise<void> => {
+  const url = `https://api.github.com/repos/${repo}/commits/${branch}`;
+
+  try {
+    const response = await axios.get(url, {
+      headers: { Authorization: `token ${token}` },
+    });
+
+    if (response.data && response.data.sha) {
+      const commitData: CommitLogEntry = {
+        timestamp: new Date().toISOString(),
+        commitHash: response.data.sha,
+        message: response.data.commit.message,
+        filesChanged: response.data.files.map(
+          (file: { fileName: string }) => file.fileName
+        ),
+        repoName: repo,
+        branch: branch,
+        authorName: "",
+        authorEmail: "",
+        commitUrl: "",
+        additions: 0,
+        deletions: 0,
+        totalChanges: 0,
+      };
+
+      logCommit(commitData);
+    }
+  } catch (error) {
+    console.error("Error fetching latest commit:", error);
+  }
+};

--- a/src/types/commitLog.ts
+++ b/src/types/commitLog.ts
@@ -1,0 +1,16 @@
+export interface CommitLogEntry {
+  timestamp: string; // ISO string format "YYYY-MM-DDTHH:mm:ss"
+  commitHash: string;
+  message: string;
+  filesChanged: string[];
+  repoName: string;
+  branch: string;
+  authorName: string;
+  authorEmail: string;
+  commitUrl: string;
+  additions: number;
+  deletions: number;
+  totalChanges: number;
+  commitDurations?: number;
+  tags?: string[];
+}

--- a/src/utils/commitLogger.ts
+++ b/src/utils/commitLogger.ts
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+import { CommitLogEntry } from "../types/commitLog";
+
+const LOGS_FILE = path.join(__dirname, "../../commitLogs.json");
+
+/**
+ * Appends a commit entry to the log file.
+ * @param commitData - Commit details
+ */
+export const logCommit = (commitData: CommitLogEntry): void => {
+  let logs: CommitLogEntry[] = [];
+
+  // Read existing logs if the file exists
+  if (fs.existsSync(LOGS_FILE)) {
+    const data = fs.readFileSync(LOGS_FILE, "utf-8");
+    logs = JSON.parse(data) as CommitLogEntry[];
+  }
+
+  // Append new commit entry
+  logs.push(commitData);
+
+  // Write updated logs back to file
+  fs.writeFileSync(LOGS_FILE, JSON.stringify(logs, null, 2), "utf-8");
+};


### PR DESCRIPTION
- Define interface for commit log structure.
- Implement function to store commit logs in a file. (For now, later will be stored in database)
- Add functionality to fetch the latest commit details from GitHub.
- Persist commit logs in a JSON file with structured metadata. (For now, later will be stored in database).